### PR TITLE
feat: enrich list_windows with isActive and windowCount (#11)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/adr/004-mcp-channels-over-notifications.md` — decision record for channels-as-push.
 - `scripts/push-test-server.mjs` — minimal harness emitting standard MCP notifications every 5s. Confirmed negative result against Claude Code v2.1.58.
 - `scripts/channel-test-server.mjs` — minimal harness emitting `notifications/claude/channel` via the `experimental: { "claude/channel": {} }` capability. Confirmed positive result against Claude Code v2.1.80+.
+- `list_windows` tool enriched with `isActive` (foreground window flag via `GetForegroundWindow()`) and `windowCount` (visible windows per process) — resolves #11. Output marks active windows with `*` and shows `(N windows)` suffix for multi-window processes.
 - Full-screen capture mode — `capture` and `query` tools now support `mode: "screen"` parameter to capture the entire primary monitor instead of a specific window. Requires `"__screen__"` in allowlist for security. PowerShell uses `Screen.PrimaryScreen.Bounds` + `CopyFromScreen()`.
 - `processes` MCP tool — lists running Windows processes with CPU usage, memory (MB), and PID. Supports `name` filter (substring), `limit` (default 30), and `sort_by` (`cpu`/`memory`). Implemented via `Get-Process` in PowerShell, audit-logged.
 - `clipboard` MCP tool — reads current Windows clipboard content (text → string, image → base64 PNG, or empty) and writes text to the clipboard. Implemented via `System.Windows.Forms.Clipboard` in PowerShell, no shell interpolation, audit-logged.

--- a/scripts/list-windows.ps1
+++ b/scripts/list-windows.ps1
@@ -29,6 +29,9 @@ public class WindowEnumerator {
     [DllImport("user32.dll")]
     public static extern bool IsIconic(IntPtr hWnd);
 
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetForegroundWindow();
+
     public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
 
     [StructLayout(LayoutKind.Sequential)]
@@ -43,6 +46,9 @@ public class WindowEnumerator {
 
 try {
     $windows = @()
+
+    # Capture foreground window handle once before enumeration
+    $script:foregroundHwnd = [WindowEnumerator]::GetForegroundWindow()
 
     $callback = [WindowEnumerator+EnumWindowsProc]{
         param($hWnd, $lParam)
@@ -80,6 +86,8 @@ try {
 
         $isMinimized = [WindowEnumerator]::IsIconic($hWnd)
 
+        $isActive = [bool]($hWnd.ToInt64() -eq $script:foregroundHwnd.ToInt64())
+
         $script:windows += @{
             title = $title
             processName = $processName
@@ -87,12 +95,28 @@ try {
             width = $width
             height = $height
             minimized = [bool]$isMinimized
+            isActive = $isActive
         }
 
         return $true
     }
 
     [WindowEnumerator]::EnumWindows($callback, [IntPtr]::Zero) | Out-Null
+
+    # Pass 2: compute windowCount per processId and assign back to each entry
+    # Note: avoid $pid — it's a PowerShell read-only automatic variable
+    $countByPid = @{}
+    foreach ($w in $windows) {
+        $procId = $w.processId
+        if ($countByPid.ContainsKey($procId)) {
+            $countByPid[$procId]++
+        } else {
+            $countByPid[$procId] = 1
+        }
+    }
+    foreach ($w in $windows) {
+        $w.windowCount = $countByPid[$w.processId]
+    }
 
     $result = @{
         windows = $windows

--- a/src/list-windows.ts
+++ b/src/list-windows.ts
@@ -14,6 +14,8 @@ export interface WindowInfo {
 	width: number;
 	height: number;
 	minimized: boolean;
+	isActive: boolean;
+	windowCount: number;
 }
 
 export interface ListWindowsResult {
@@ -70,8 +72,13 @@ export function listWindows(timeoutMs = 15000): Promise<ListWindowsResult> {
 						reject(new Error(result.error));
 						return;
 					}
+					const windows = (result.windows || []).map((w) => ({
+						...w,
+						isActive: w.isActive ?? false,
+						windowCount: w.windowCount ?? 1,
+					}));
 					resolve_({
-						windows: result.windows || [],
+						windows,
 						count: result.count || 0,
 					});
 				} catch {

--- a/src/server.ts
+++ b/src/server.ts
@@ -302,7 +302,10 @@ export function createServer(): McpServer {
 
 			const windows = result.windows.map((w) => {
 				const allowed = isWindowAllowed(cfg, w.title);
-				return `${allowed ? "+" : "-"} ${w.title} [${w.processName}] (${w.width}x${w.height}${w.minimized ? ", minimized" : ""})`;
+				const allowedMarker = allowed ? "+" : "-";
+				const activeMarker = w.isActive ? "*" : " ";
+				const windowCountSuffix = w.windowCount > 1 ? ` (${w.windowCount} windows)` : "";
+				return `${allowedMarker}${activeMarker} ${w.title} [${w.processName}] (${w.width}x${w.height}${w.minimized ? ", minimized" : ""})${windowCountSuffix}`;
 			});
 
 			writeAuditEntry({
@@ -317,7 +320,7 @@ export function createServer(): McpServer {
 				content: [
 					{
 						type: "text",
-						text: `Found ${result.count} windows:\n\n${windows.join("\n")}\n\n(+ = capturable, - = blocked by allowlist)`,
+						text: `Found ${result.count} windows:\n\n${windows.join("\n")}\n\n(+ = capturable, - = blocked by allowlist, * = active window, +* = active and capturable)`,
 					},
 				],
 			};

--- a/tests/list-windows.test.ts
+++ b/tests/list-windows.test.ts
@@ -15,7 +15,7 @@ describe("list-windows module", () => {
 		execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
 			callback(
 				null,
-				'{"windows":[{"title":"Chrome","processName":"chrome","processId":1,"width":1200,"height":800,"minimized":false}],"count":1}',
+				'{"windows":[{"title":"Chrome","processName":"chrome","processId":1,"width":1200,"height":800,"minimized":false,"isActive":false,"windowCount":1}],"count":1}',
 				"",
 			);
 		});
@@ -72,7 +72,7 @@ describe("list-windows module", () => {
 		execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
 			callback(
 				null,
-				'INFO: preparing list\n{"windows":[{"title":"Chrome","processName":"chrome","processId":1,"width":1200,"height":800,"minimized":false}],"count":1}\n',
+				'INFO: preparing list\n{"windows":[{"title":"Chrome","processName":"chrome","processId":1,"width":1200,"height":800,"minimized":false,"isActive":false,"windowCount":1}],"count":1}\n',
 				"",
 			);
 		});
@@ -81,5 +81,180 @@ describe("list-windows module", () => {
 		const result = await listWindows();
 		expect(result.count).toBe(1);
 		expect(result.windows[0]?.processName).toBe("chrome");
+	});
+
+	// --- isActive / windowCount tests ---
+
+	it("passes through isActive: true from PS output", async () => {
+		execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+			callback(
+				null,
+				JSON.stringify({
+					windows: [
+						{
+							title: "VS Code",
+							processName: "code",
+							processId: 42,
+							width: 1920,
+							height: 1080,
+							minimized: false,
+							isActive: true,
+							windowCount: 1,
+						},
+					],
+					count: 1,
+				}),
+				"",
+			);
+		});
+
+		const { listWindows } = await import("../src/list-windows.js");
+		const result = await listWindows();
+
+		expect(result.windows[0]?.isActive).toBe(true);
+	});
+
+	it("passes through isActive: false from PS output", async () => {
+		execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+			callback(
+				null,
+				JSON.stringify({
+					windows: [
+						{
+							title: "Notepad",
+							processName: "notepad",
+							processId: 99,
+							width: 800,
+							height: 600,
+							minimized: false,
+							isActive: false,
+							windowCount: 1,
+						},
+					],
+					count: 1,
+				}),
+				"",
+			);
+		});
+
+		const { listWindows } = await import("../src/list-windows.js");
+		const result = await listWindows();
+
+		expect(result.windows[0]?.isActive).toBe(false);
+	});
+
+	it("passes through windowCount for a process with multiple windows", async () => {
+		execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+			callback(
+				null,
+				JSON.stringify({
+					windows: [
+						{
+							title: "Chrome - Tab 1",
+							processName: "chrome",
+							processId: 10,
+							width: 1200,
+							height: 800,
+							minimized: false,
+							isActive: true,
+							windowCount: 3,
+						},
+						{
+							title: "Chrome - Tab 2",
+							processName: "chrome",
+							processId: 10,
+							width: 1200,
+							height: 800,
+							minimized: false,
+							isActive: false,
+							windowCount: 3,
+						},
+						{
+							title: "Chrome - Tab 3",
+							processName: "chrome",
+							processId: 10,
+							width: 1200,
+							height: 800,
+							minimized: true,
+							isActive: false,
+							windowCount: 3,
+						},
+					],
+					count: 3,
+				}),
+				"",
+			);
+		});
+
+		const { listWindows } = await import("../src/list-windows.js");
+		const result = await listWindows();
+
+		expect(result.count).toBe(3);
+		for (const w of result.windows) {
+			expect(w.windowCount).toBe(3);
+		}
+	});
+
+	it("correctly identifies single active window among multiple processes", async () => {
+		execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+			callback(
+				null,
+				JSON.stringify({
+					windows: [
+						{
+							title: "VS Code",
+							processName: "code",
+							processId: 1,
+							width: 1920,
+							height: 1080,
+							minimized: false,
+							isActive: true,
+							windowCount: 1,
+						},
+						{
+							title: "Firefox",
+							processName: "firefox",
+							processId: 2,
+							width: 1280,
+							height: 720,
+							minimized: false,
+							isActive: false,
+							windowCount: 1,
+						},
+						{
+							title: "Terminal",
+							processName: "wt",
+							processId: 3,
+							width: 900,
+							height: 500,
+							minimized: false,
+							isActive: false,
+							windowCount: 2,
+						},
+					],
+					count: 3,
+				}),
+				"",
+			);
+		});
+
+		const { listWindows } = await import("../src/list-windows.js");
+		const result = await listWindows();
+
+		const activeWindows = result.windows.filter((w) => w.isActive);
+		expect(activeWindows).toHaveLength(1);
+		expect(activeWindows[0]?.title).toBe("VS Code");
+	});
+
+	it("returns count: 0 and empty windows array for empty result", async () => {
+		execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+			callback(null, JSON.stringify({ windows: [], count: 0 }), "");
+		});
+
+		const { listWindows } = await import("../src/list-windows.js");
+		const result = await listWindows();
+
+		expect(result.count).toBe(0);
+		expect(result.windows).toHaveLength(0);
 	});
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -394,6 +394,8 @@ describe("createServer", () => {
 					width: 1200,
 					height: 800,
 					minimized: false,
+					isActive: false,
+					windowCount: 1,
 				},
 				{
 					title: "Mozilla Firefox",
@@ -402,6 +404,8 @@ describe("createServer", () => {
 					width: 1100,
 					height: 780,
 					minimized: false,
+					isActive: false,
+					windowCount: 1,
 				},
 			],
 			count: 2,
@@ -413,8 +417,100 @@ describe("createServer", () => {
 		const text = result.content[0]?.text ?? "";
 
 		expect(text).toContain("Found 2 windows:");
-		expect(text).toContain("+ Google Chrome - New Tab");
-		expect(text).toContain("- Mozilla Firefox");
+		// Format is: [allow][active] title — space for inactive window
+		expect(text).toContain("+  Google Chrome - New Tab");
+		expect(text).toContain("-  Mozilla Firefox");
+	});
+
+	it("marks active window with * in list_windows output", async () => {
+		loadConfigMock.mockResolvedValue({});
+		isWindowAllowedMock.mockReturnValue(true);
+		listWindowsMock.mockResolvedValue({
+			windows: [
+				{
+					title: "VS Code",
+					processName: "code",
+					processId: 1,
+					width: 1920,
+					height: 1080,
+					minimized: false,
+					isActive: true,
+					windowCount: 1,
+				},
+				{
+					title: "Terminal",
+					processName: "wt",
+					processId: 2,
+					width: 900,
+					height: 500,
+					minimized: false,
+					isActive: false,
+					windowCount: 1,
+				},
+			],
+			count: 2,
+		});
+
+		const server = createServer();
+		const list = getToolHandler(server, "list_windows");
+		const result = await list({});
+		const text = result.content[0]?.text ?? "";
+
+		// Active window line contains the * marker between allow marker and title
+		expect(text).toMatch(/\+\* VS Code/);
+		// Inactive window has space instead of *
+		expect(text).toMatch(/\+ {2}Terminal/);
+	});
+
+	it("appends (N windows) suffix when windowCount > 1", async () => {
+		loadConfigMock.mockResolvedValue({});
+		isWindowAllowedMock.mockReturnValue(true);
+		listWindowsMock.mockResolvedValue({
+			windows: [
+				{
+					title: "Chrome - Tab A",
+					processName: "chrome",
+					processId: 10,
+					width: 1200,
+					height: 800,
+					minimized: false,
+					isActive: false,
+					windowCount: 3,
+				},
+				{
+					title: "Notepad",
+					processName: "notepad",
+					processId: 20,
+					width: 800,
+					height: 600,
+					minimized: false,
+					isActive: false,
+					windowCount: 1,
+				},
+			],
+			count: 2,
+		});
+
+		const server = createServer();
+		const list = getToolHandler(server, "list_windows");
+		const result = await list({});
+		const text = result.content[0]?.text ?? "";
+
+		expect(text).toContain("(3 windows)");
+		expect(text).not.toMatch(/Notepad.*\(\d+ windows\)/);
+	});
+
+	it("legend line mentions active window marker", async () => {
+		loadConfigMock.mockResolvedValue({});
+		isWindowAllowedMock.mockReturnValue(true);
+		listWindowsMock.mockResolvedValue({ windows: [], count: 0 });
+
+		const server = createServer();
+		const list = getToolHandler(server, "list_windows");
+		const result = await list({});
+		const text = result.content[0]?.text ?? "";
+
+		expect(text).toContain("* = active window");
 	});
 
 	it("passes max_width to captureWindow", async () => {


### PR DESCRIPTION
## Summary
- `list_windows` tool returns two new fields per window: **`isActive`** (foreground window via `GetForegroundWindow()`) and **`windowCount`** (visible windows per process)
- Text output adds `*` marker for active window and ` (N windows)` suffix for multi-window processes
- Resolves #11

## Orchestrator smoke-test
This PR is the **first run** of the new agent-orchestrator workflow (see plan). Phase reports on #11:
1. **Plan** (architect) — ADR: GetForegroundWindow P/Invoke + two-pass aggregation
2. **Implement** (ps-specialist + coder, parallel) — PS + TS in one pass
3. **Verify** (reviewer + tester, parallel) — P1/P2 addressed (runtime defaults for back-compat, legend extended)
4. **Document** (documenter) — CHANGELOG [Unreleased] entry

## Test plan
- [x] `pnpm build` — TypeScript compiles cleanly
- [x] `pnpm test` — 19 files, 249 tests, all green
- [x] Live PS smoke-test — `isActive: true` on foreground VS Code, `windowCount: 6` for 6 Code windows sharing PID 19964
- [ ] CI green on PR
- [ ] Manual sanity check on the `list_windows` MCP tool via Claude Code after merge

## Notes
- No breaking changes — new fields are additive
- Runtime defaults (`isActive ?? false`, `windowCount ?? 1`) guard against older PS output if dist/ and scripts/ ever diverge
- `\$pid` avoided in PowerShell loop (read-only automatic variable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)